### PR TITLE
Compatible with 'space between' utilities

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -22,5 +22,6 @@ module.exports = {
         'unicorn/prevent-abbreviations': 'off',
         'multiline-comment-style': 'off',
         'capitalized-comments': 'off',
+        'unicorn/no-array-for-each': 'off',
     },
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dcasia/mini-program-tailwind-webpack-plugin",
-  "version": "1.3.4",
+  "version": "1.4.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@dcasia/mini-program-tailwind-webpack-plugin",
-      "version": "1.3.4",
+      "version": "1.4.0",
       "license": "ISC",
       "dependencies": {
         "@babel/core": "^7.17.5",
@@ -30,6 +30,7 @@
         "jest": "^27.5.1",
         "rollup": "^2.68.0",
         "rollup-plugin-dts": "^4.2.1",
+        "tslib": "^2.4.0",
         "vite": "^2.9.9",
         "webpack": "^5.69.1"
       }
@@ -8991,9 +8992,9 @@
       }
     },
     "node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
       "dev": true
     },
     "node_modules/tsutils": {
@@ -9010,6 +9011,12 @@
       "peerDependencies": {
         "typescript": ">=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta"
       }
+    },
+    "node_modules/tsutils/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -16256,9 +16263,9 @@
       }
     },
     "tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
       "dev": true
     },
     "tsutils": {
@@ -16268,6 +16275,14 @@
       "dev": true,
       "requires": {
         "tslib": "^1.8.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+          "dev": true
+        }
       }
     },
     "type-check": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dcasia/mini-program-tailwind-webpack-plugin",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "让你的小程序用上原汁原味的 Tailwind/Windi CSS",
   "keywords": [
     "mini-program",

--- a/package.json
+++ b/package.json
@@ -3,15 +3,19 @@
   "version": "1.4.0",
   "description": "让你的小程序用上原汁原味的 Tailwind/Windi CSS",
   "keywords": [
-    "miniprogram",
     "mini-program",
+    "tailwind",
     "tailwindcss",
     "windicss",
     "wechat",
     "taro",
     "css",
     "postcss",
-    "uni-app"
+    "uni-app",
+    "miniprogram",
+    "weapp",
+    "atomic-css",
+    "unocss"
   ],
   "main": "dist/index.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "jest": "^27.5.1",
     "rollup": "^2.68.0",
     "rollup-plugin-dts": "^4.2.1",
+    "tslib": "^2.4.0",
     "vite": "^2.9.9",
     "webpack": "^5.69.1"
   },

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -4,6 +4,9 @@ import { TaroFramework } from './enum'
 export interface Options {
     enableRpx?: boolean,
     designWidth?: number,
+    utilitiesSettings?: {
+        spaceBetweenItems?: string[],
+    },
 }
 
 export interface TaroWebpackPluginOptions {

--- a/src/postcss/index.ts
+++ b/src/postcss/index.ts
@@ -7,7 +7,7 @@ export function transformSelector(options: Options) {
     const processed = Symbol('processed')
     const defaultSpaceBetweenItems = [ 'view', 'button', 'text', 'image' ]
     const usersSpaceBetweenItems = options?.utilitiesSettings?.spaceBetweenItems || []
-    const spaceBetweenItems = [ ...defaultSpaceBetweenItems, ...usersSpaceBetweenItems ]
+    const spaceBetweenItems = Array.from(new Set([ ...defaultSpaceBetweenItems, ...usersSpaceBetweenItems ]))
     const customReplacement = new Map()
 
     /**

--- a/src/postcss/index.ts
+++ b/src/postcss/index.ts
@@ -13,6 +13,15 @@ export function transformSelector() {
             if (!node[ processed ]) {
 
                 node.selector = handleCharacters(node.selector, FileType.Style)
+
+                /**
+                 * A polyfill that is compatible 'space-[x,y]-\d' syntax
+                 * Note that in mini program environment ':not()' selector can only be used when it's combined with other selectors
+                 * e.g. view:not() works but the standalone :not() selector couldn't work
+                 */
+                // eslint-disable-next-line @typescript-eslint/padding-line-between-statements
+                node.selector = node.selector.replace(/^(\.space-\w)(-.+?)\s.*/, '$1$2:not($1-reverse) > view:not([hidden]):not(:first-child), $1$2$1-reverse > view:not([hidden]):not(:last-child)')
+                node.selector = node.selector.replace(/^(\.space-\w-reverse).*/, '$1 > view:not([hidden])')
                 node[ processed ] = true
 
             }

--- a/src/postcss/index.ts
+++ b/src/postcss/index.ts
@@ -1,10 +1,22 @@
 import { FileType } from '../enum'
-import { handleCharacters } from '../utilities'
+import { customReplace, handleCharacters } from '../utilities'
 import { Options } from '../interfaces'
 
-export function transformSelector() {
+export function transformSelector(options: Options) {
 
     const processed = Symbol('processed')
+    const defaultSpaceBetweenItems = [ 'view', 'button', 'text', 'image' ]
+    const usersSpaceBetweenItems = options?.utilitiesSettings?.spaceBetweenItems || []
+    const spaceBetweenItems = [ ...defaultSpaceBetweenItems, ...usersSpaceBetweenItems ]
+    const customReplacement = new Map()
+
+    /**
+     * A polyfill that is compatible 'space-[x,y]-\d' syntax
+     * Note that in mini program environment ':not()' selector can only be used when it's combined with other selectors
+     * e.g. view:not() works but the standalone :not() selector couldn't work
+     */
+    customReplacement.set(/^(\.-?space-\w)(-.+?)\s.*/, spaceBetweenItems.map(item => `$1$2:not($1-reverse) > ${ item }:not([hidden]):not(:first-child), $1$2$1-reverse > ${ item }:not([hidden]):not(:last-child)`).join(', '))
+    customReplacement.set(/^(\.-?space-\w-reverse).*/, spaceBetweenItems.map(item => `$1 > ${ item }:not([hidden])`).join(', '))
 
     return {
         postcssPlugin: 'transformSelectorName',
@@ -13,15 +25,7 @@ export function transformSelector() {
             if (!node[ processed ]) {
 
                 node.selector = handleCharacters(node.selector, FileType.Style)
-
-                /**
-                 * A polyfill that is compatible 'space-[x,y]-\d' syntax
-                 * Note that in mini program environment ':not()' selector can only be used when it's combined with other selectors
-                 * e.g. view:not() works but the standalone :not() selector couldn't work
-                 */
-                // eslint-disable-next-line @typescript-eslint/padding-line-between-statements
-                node.selector = node.selector.replace(/^(\.space-\w)(-.+?)\s.*/, '$1$2:not($1-reverse) > view:not([hidden]):not(:first-child), $1$2$1-reverse > view:not([hidden]):not(:last-child)')
-                node.selector = node.selector.replace(/^(\.space-\w-reverse).*/, '$1 > view:not([hidden])')
+                node.selector = customReplace(node.selector, customReplacement)
                 node[ processed ] = true
 
             }

--- a/src/style-handler.ts
+++ b/src/style-handler.ts
@@ -5,7 +5,7 @@ import { transformSelector, transformValue } from './postcss'
 export function handleStyle(rawSource: string, option?: Options) {
 
     const processor = postcss()
-        .use(transformSelector)
+        .use(transformSelector(option))
 
     if (option?.enableRpx) {
         processor.use(transformValue(option))

--- a/src/universal-handler.ts
+++ b/src/universal-handler.ts
@@ -15,7 +15,7 @@ export function handleSource(fileType: FileType, source: string, options?: Optio
 
 }
 
-export default {
+export {
     handleStyle,
     handleTemplate,
 }

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -63,3 +63,13 @@ export function handleCharacters(content, type: FileType) {
     return content
 
 }
+
+export function customReplace(raw: string, rules: Map<RegExp, string>) {
+
+    rules.forEach((target, exp) => {
+        raw = raw.replace(exp, target)
+    })
+
+    return raw
+
+}


### PR DESCRIPTION
A polyfill that is compatible `space-[x,y]-\d` syntax, which is called [space between](https://windicss.org/utilities/layout/spacing.html#space-between-y), a nice utility provided by Windi CSS.
Note that the runtime error caused by using this syntax is because in mini program environment `:not()` selector can only be used when it's combined with other selectors.
e.g. `view:not()` works but the standalone `:not()` selector couldn't work.